### PR TITLE
Make testing work without gulp

### DIFF
--- a/gulp/unit-tests.js
+++ b/gulp/unit-tests.js
@@ -1,57 +1,21 @@
 'use strict';
 
 var gulp = require('gulp');
-
-var $ = require('gulp-load-plugins')();
-
-var wiredep = require('wiredep');
 var karma = require('karma');
-var concat = require('concat-stream');
-var _ = require('lodash');
 
-module.exports = function(options) {
-  function listFiles(callback) {
-    var bowerDeps = wiredep({
-      directory: 'bower_components',
-      dependencies: true,
-      devDependencies: true
-    });
-
-    var specFiles = [
-      options.src + '/**/*.spec.js',
-      options.src + '/**/*.mock.js'
-    ];
-
-    var htmlFiles = [
-      options.tmp + '/serve/**/*.html',
-      options.src + '/**/*.html'
-    ];
-
-    gulp.src([options.src + '/*.js', options.src + '/**/*.js'])
-      .pipe($.angularFilesort()).on('error', options.errorHandler('AngularFilesort'))
-      .pipe(concat(function(files) {
-        callback(bowerDeps.js
-          .concat(_.pluck(files, 'path'))
-          .concat(htmlFiles)
-          .concat(specFiles));
-      }));
-  }
-
+module.exports = function() {
   function runTests (singleRun, done) {
-    listFiles(function(files) {
-      karma.server.start({
-        configFile: __dirname + '/../karma.conf.js',
-        files: files,
-        reporters: singleRun ? ['dots'] : ['notify', 'mocha'],
-        singleRun: singleRun,
-        autoWatch: !singleRun,
-      }, function(exitStatus) {
-        if (singleRun) {
-          done(exitStatus ? "There are failing unit tests" : undefined);
-        } else {
-          done(exitStatus);
-        }
-      });
+    karma.server.start({
+      configFile: __dirname + '/../karma.conf.js',
+      reporters: singleRun ? ['dots'] : ['notify', 'mocha'],
+      singleRun: singleRun,
+      autoWatch: !singleRun
+    }, function(exitStatus) {
+      if (singleRun) {
+        done(exitStatus ? "There are failing unit tests" : undefined);
+      } else {
+        done(exitStatus);
+      }
     });
   }
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,13 +1,36 @@
 'use strict';
 
+var wiredep = require('wiredep');
+var bowerDeps = wiredep({
+  directory: 'bower_components',
+  dependencies: true,
+  devDependencies: true
+});
+
+var files = [];
+
+bowerDeps.js.forEach(function(file) {
+  files.push({pattern: __dirname + '/' + file, included: true, served: true, watched: false});
+});
+
+files.push('app/**/*.js');
+
 module.exports = function(config) {
 
   var configuration = {
-    frameworks: ['jasmine'],
+    frameworks: ['angular-filesort', 'jasmine'],
 
     ngHtml2JsPreprocessor: {
       stripPrefix: '.tmp/serve/',
       moduleName: 'pmltq.shared'
+    },
+
+    files: files,
+
+    angularFilesort: {
+      whitelist: [
+        'app/**/*.js', '!app/**/*.(spec|mock).js'
+      ]
     },
 
     reporters : 'dots',
@@ -17,11 +40,12 @@ module.exports = function(config) {
     browsers : ['PhantomJS'],
 
     plugins : [
-      'karma-phantomjs-launcher',
+      'karma-angular-filesort',
       'karma-jasmine',
-      'karma-ng-html2js-preprocessor',
       'karma-mocha-reporter',
-      'karma-notify-reporter'
+      'karma-ng-html2js-preprocessor',
+      'karma-notify-reporter',
+      'karma-phantomjs-launcher'
     ],
 
     // reporter options

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jade": "~1.8.1",
     "jshint-stylish": "~1.0.0",
     "karma": "~0.12.31",
+    "karma-angular-filesort": "^0.1.0",
     "karma-jasmine": "~0.3.1",
     "karma-mocha-reporter": "^1.0.2",
     "karma-ng-html2js-preprocessor": "~0.1.2",


### PR DESCRIPTION
This can be done using [karma angular filesort plugin](https://github.com/wilsonjackson/karma-angular-filesort)

This also allow run karma tests from IDE.