### PR TITLE
Correctly highlight matched nodes

### DIFF
--- a/app/pmltq.less
+++ b/app/pmltq.less
@@ -38,7 +38,7 @@
 
 .right.aligned {
   .button {
-    margin: 0em 0em 0em 0.25em;
+    margin: 0 0 0 0.25em;
   }
 }
 
@@ -103,7 +103,7 @@ pre {
 }
 
 .ui.grid > .fitted.column {
-  padding-top: 0px;
-  padding-bottom: 0px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 

--- a/app/result/result-svg.directive.less
+++ b/app/result/result-svg.directive.less
@@ -60,3 +60,7 @@
 }
 //.generate-node-classes(0) {}
 .generate-node-classes (@nodes-count);
+
+.node {
+  cursor: pointer;
+}

--- a/app/result/sentence-token.directive.js
+++ b/app/result/sentence-token.directive.js
@@ -15,6 +15,10 @@ angular.module('pmltq.result').directive('sentenceToken', function($) {
       $scope.token.update = function () {
         $scope.$apply();
       };
+
+      $element.on('click', function () {
+        $scope.token.result.animateNodes($scope.token.ids);
+      });
     }
   };
 });

--- a/app/result/sentence-token.directive.js
+++ b/app/result/sentence-token.directive.js
@@ -12,11 +12,9 @@ angular.module('pmltq.result').directive('sentenceToken', function($) {
 
     link: function($scope, $element, $attrs, sentenceController) {
 
-      $($element).bind({
-        click: function() {
-
-        }
-      });
+      $scope.token.update = function () {
+        $scope.$apply();
+      };
     }
   };
 });

--- a/app/result/sentence-token.directive.less
+++ b/app/result/sentence-token.directive.less
@@ -1,7 +1,8 @@
 .sentence-token {
   cursor: pointer;
 
-  &:hover {
-    background-color: #ffa;
+  &:hover, &.highlight {
+    background-color: #C96DF7 !important;
+    color: #ffffff !important;
   }
 }

--- a/app/result/sentence.factory.js
+++ b/app/result/sentence.factory.js
@@ -10,7 +10,8 @@ angular.module('pmltq.result').factory('sentence', function(_, $) {
     var res = {
           classes: {},
           style: {},
-          ids: []
+          ids: [],
+          update: angular.noop
         },
         parts = str.split(/\s+/);
 
@@ -28,7 +29,7 @@ angular.module('pmltq.result').factory('sentence', function(_, $) {
           }
           break;
         case '#':
-          res.ids.push(part);
+          res.ids.push(part.substring(1));
           break;
         default:
           res.classes[part] = true;
@@ -47,7 +48,7 @@ angular.module('pmltq.result').factory('sentence', function(_, $) {
       }
 
       if (!this.idsIndex) {
-        this.rebuildtokenIndex();
+        this.rebuildTokenIndex();
       }
 
       var tokens = this.idsIndex[tokenId];
@@ -55,12 +56,14 @@ angular.module('pmltq.result').factory('sentence', function(_, $) {
         for (var i = tokens.length - 1; i >= 0; i--) {
           var token = tokens[i];
           token.classes.highlight = true;
+          token.update();
         }
       }
     },
     clearHighlight: function() {
       for (var i = this.length - 1; i >= 0; i--) {
         this[i].classes.highlight = false;
+        this[i].update();
       }
     },
     rebuildTokenIndex: function() {

--- a/app/result/sentence.factory.js
+++ b/app/result/sentence.factory.js
@@ -93,6 +93,7 @@ angular.module('pmltq.result').factory('sentence', function(_, $) {
           classStr = $this.attr('class'),
           parsedData = parseClasses(classStr); // TODO: Convert this to some class maybe
       parsedData.text = $this.text();
+      parsedData.result = result;
       sentence.push(parsedData);
     });
 

--- a/app/result/tred-svg.factory.js
+++ b/app/result/tred-svg.factory.js
@@ -129,6 +129,18 @@ angular.module('pmltq.result').factory('tredSvg', function ($, _, Snap, sentence
               self.unmarkNode(this);
             }
           });
+
+          node.hover(function () {
+            var s = self.data.sentence;
+            if (s) {
+              s.highlightToken(nodeId);
+            }
+          }, function () {
+            var s = self.data.sentence;
+            if (s) {
+              s.clearHighlight();
+            }
+          });
         });
       }
 

--- a/app/result/tred-svg.factory.js
+++ b/app/result/tred-svg.factory.js
@@ -46,9 +46,35 @@ angular.module('pmltq.result').factory('tredSvg', function ($, _, Snap, sentence
    * @param {Snap.Element} node
    */
   function animateNode(node) {
-    node.animate({rx: '*=4', ry: '*=4'}, 1000, mina.easein, function () {
-      node.animate({rx: '/=4', ry: '/=4'}, 1000, mina.easeout);
+    if (!node.data('original-attrs')) {
+      node.data('original-attrs', {
+        rx: node.attr('rx'),
+        ry: node.attr('ry')
+      });
+    }
+    var originalAttrs = node.data('original-attrs');
+
+    node.animate({rx: originalAttrs.rx * 4, ry: originalAttrs.ry * 4}, 1000, mina.easein, function () {
+      node.animate(originalAttrs, 1000, mina.easeout);
     });
+  }
+
+  /**
+   * Creates mark element (Ellipse or Circle)
+   * @param {Snap.Element} node
+   * @return {Snap.Element}
+   */
+  function createNodeMark(node) {
+    var bbox = node.getBBox();
+
+    switch (node.type) {
+      case 'rect':
+      case 'ellipse':
+        return node.paper.ellipse(bbox.cx, bbox.cy, bbox.w + 5, bbox.h + 5);
+      // case 'circle':
+      default:
+        return node.paper.circle(bbox.cx, bbox.cy, bbox.r0 + 5);
+    }
   }
 
   /**
@@ -58,6 +84,7 @@ angular.module('pmltq.result').factory('tredSvg', function ($, _, Snap, sentence
   function TredSvg(svg) {
     this.svg = svg;
     this.data = {};
+    this.markedNodes = {};
   }
 
   TredSvg.prototype = {
@@ -94,11 +121,59 @@ angular.module('pmltq.result').factory('tredSvg', function ($, _, Snap, sentence
           if (nodeId) {
             self.nodesMap[nodeId] = node;
           }
+          node.click(function () {
+            //noinspection JSPotentiallyInvalidUsageOfThis
+            if (!this.data('marked')) {
+              self.markNode(this);
+            } else {
+              self.unmarkNode(this);
+            }
+          });
         });
       }
 
       return self.nodes;
     },
+
+    /**
+     * @param {Snap.Element} node
+     * @private
+     */
+    markNode: function(node) {
+      var self = this;
+
+      if (self.markedNodes[node.id]) {
+        return;
+      }
+
+      var mark = self.markedNodes[node.id] = createNodeMark(node);
+      mark.attr({
+        fill: 'none',
+        stroke: 'red',
+        strokeWidth: 2
+      });
+      node.parent().append(mark);
+      node.data('marked', true);
+
+      return mark;
+    },
+
+    /**
+     * @param {Snap.Element} node
+     * @private
+     */
+    unmarkNode: function(node) {
+      var self = this;
+
+      if (!self.markedNodes[node.id]) {
+        return;
+      }
+
+      self.markedNodes[node.id].remove();
+      node.data('marked', false);
+      delete self.markedNodes[node.id];
+    },
+
     /**
      * Attach 'matched-node-*' classes specified nodes
      * @param {Array} nodes
@@ -134,12 +209,16 @@ angular.module('pmltq.result').factory('tredSvg', function ($, _, Snap, sentence
       content.node.setAttribute('width', Math.round(box.width + 10));
       content.node.setAttribute('height', Math.round(box.height + 20));
     },
+
+    /**
+     * @return {sentence}
+     */
     sentence: function() {
       var self = this, data = self.data;
 
       if (_.isUndefined(data.sentence)) {
         var descNode = self.$content().children('desc').remove();
-        data.sentence = sentence(descNode.find('span[class]'));
+        data.sentence = sentence(descNode.find('span[class]'), self);
       }
 
       return data.sentence;

--- a/app/result/tred-svg.factory.js
+++ b/app/result/tred-svg.factory.js
@@ -46,16 +46,16 @@ angular.module('pmltq.result').factory('tredSvg', function ($, _, Snap, sentence
    * @param {Snap.Element} node
    */
   function animateNode(node) {
-    if (!node.data('original-attrs')) {
-      node.data('original-attrs', {
-        rx: node.attr('rx'),
-        ry: node.attr('ry')
-      });
-    }
-    var originalAttrs = node.data('original-attrs');
+    var mark = createNodeMark(node);
+    mark.attr({
+      fill: 'none',
+      stroke: 'red',
+      strokeWidth: 2
+    });
+    node.parent().append(mark);
 
-    node.animate({rx: originalAttrs.rx * 4, ry: originalAttrs.ry * 4}, 1000, mina.easein, function () {
-      node.animate(originalAttrs, 1000, mina.easeout);
+    mark.animate({rx: '*=2', ry: '*=2', r: '*=2', opacity: 0}, 1000, mina.easein, function () {
+      mark.remove();
     });
   }
 
@@ -220,6 +220,21 @@ angular.module('pmltq.result').factory('tredSvg', function ($, _, Snap, sentence
         box = g.getBBox();
       content.node.setAttribute('width', Math.round(box.width + 10));
       content.node.setAttribute('height', Math.round(box.height + 20));
+    },
+
+    animateNodes: function (nodeIds) {
+      var self = this;
+
+      if (!nodeIds) { return; }
+      self.extractNodes();
+
+      for (var i = 0; i < nodeIds.length; i++) {
+        var nodeId = nodeIds[i],
+            node = self.nodesMap[nodeId];
+        if (node) {
+          animateNode(node);
+        }
+      }
     },
 
     /**


### PR DESCRIPTION
Because of the new panning plugin (https://github.com/ariutta/svg-pan-zoom) which fixes zooming issues on MacOS we need to rewrite highlighting the matched nodes (in svg and in the sentence).

In the old implementation there is also a bug for phrase trees, where it will incorrectly highlight and de-highlight parts of the sentence when clicking on child nodes.

![screen](https://cloud.githubusercontent.com/assets/1168605/7295842/241f46d2-e9ba-11e4-8bdf-343d46f893b2.png)
  