### PR TITLE
Provide list of recently used treebanks

### DIFF
--- a/app/home/home.controller.js
+++ b/app/home/home.controller.js
@@ -1,4 +1,4 @@
-angular.module('pmltq.home').controller('HomeController', function($scope, treebanks, _) {
-  $scope.featured = _.sample(treebanks, 5);
-  $scope.recentlyUsed = _.sample(treebanks, 3);
+angular.module('pmltq.home').controller('HomeController', function($scope, recentlyUsed, treebanks, _) {
+  $scope.featured = _.take(treebanks, 5);
+  $scope.recentlyUsed = _.take(recentlyUsed, 3);
 });

--- a/app/home/home.jade
+++ b/app/home/home.jade
@@ -17,8 +17,11 @@ main.ui.page.grid
   .ui.two.columns.grid
     .column
       h2.header Recently Used
-      .ui.divided.items
+      .ui.divided.items(ng-if="recentlyUsed.length > 0")
         div(treebank-list-item="tb" ui-sref="treebank.index({treebankId: tb.id})" ng-repeat="tb in recentlyUsed track by tb.id")
+      .ui.info.message(ng-if="recentlyUsed.length == 0")
+        .header No recent treebanks
+        | You will find recently used treebanks here.
     .column
       h2 Featured Treebanks
       .ui.divided.items

--- a/app/home/home.routes.js
+++ b/app/home/home.routes.js
@@ -7,6 +7,9 @@ angular.module('pmltq.home').config(function($stateProvider) {
     resolve: /*@ngInject*/ {
       treebanks: function(treebanksApi) {
         return treebanksApi.getList();
+      },
+      recentlyUsed: function(treebanksApi) {
+        return treebanksApi.recentlyUsed();
       }
     }
   });

--- a/app/treebank/treebank.controller.js
+++ b/app/treebank/treebank.controller.js
@@ -1,10 +1,13 @@
-angular.module('pmltq.treebank').controller('TreebankController', function($scope, resultHolder, treebank, history) {
-  $scope.treebank = treebank;
-  $scope.history = history;
-  $scope.result = resultHolder();
-  $scope.queryParams = {
-    timeout: 30,
-    limit: 100,
-    query: "t-node [ gram/deontmod ~ '(deb|hrt|vol|perm|poss|fac)', a/lex.rf a-node [] ];"
-  };
-});
+angular.module('pmltq.treebank')
+  .controller('TreebankController', function($scope, resultHolder, treebank, history, treebanksApi) {
+    $scope.treebank = treebank;
+    $scope.history = history;
+    $scope.result = resultHolder();
+    treebanksApi.addRecentlyUsed(treebank.id);
+
+    $scope.queryParams = {
+      timeout: 30,
+      limit: 100,
+      query: "t-node [ gram/deontmod ~ '(deb|hrt|vol|perm|poss|fac)', a/lex.rf a-node [] ];"
+    };
+  });

--- a/app/treebank/treebanks-api.service.js
+++ b/app/treebank/treebanks-api.service.js
@@ -1,59 +1,87 @@
-angular.module('pmltq.treebank').factory('treebanksApi', function (Restangular, $cacheFactory, $q, svgResult, sticker) {
-  var svgCache = $cacheFactory('svg-result-cache');
-  var stickerFactory = sticker({defaultCategory: 'Others'});
+angular.module('pmltq.treebank')
+  .factory('treebanksApi', function (_, Restangular, $cacheFactory, $q, svgResult, sticker, localStorageService) {
+    var svgCache = $cacheFactory('svg-result-cache');
+    var stickerFactory = sticker({defaultCategory: 'Others'});
+    var recentStorageKey = 'recently-used-treebanks';
 
-  var restangular = Restangular.withConfig(function (RestangularConfigurer) {
-    RestangularConfigurer.extendModel('treebanks', function (model) {
+    var restangular = Restangular.withConfig(function (RestangularConfigurer) {
+      RestangularConfigurer.setDefaultHttpFields({cache: true});
+      RestangularConfigurer.extendModel('treebanks', function (model) {
 
-      var stickers, stickersMap;
-      model.getStickers = function() {
-        if (stickers) {
+        var stickers, stickersMap;
+        model.getStickers = function() {
+          if (stickers) {
+            return stickers;
+          }
+
+          stickers = [];
+          for (var i = this.stickers.length - 1; i >= 0; i--) {
+            stickers.push(stickerFactory(this.stickers[i]));
+          }
+
           return stickers;
-        }
+        };
 
-        stickers = [];
-        for (var i = this.stickers.length - 1; i >= 0; i--) {
-          stickers.push(stickerFactory(this.stickers[i]));
-        }
+        model.hasSticker = function(stickerOrName) {
+          if (!stickersMap) {
+            stickersMap = _.transform(this.getStickers(), function(result, sticker) {
+              result[sticker.name] = sticker;
+            }, {});
+          }
 
-        return stickers;
-      };
+          if (_.isObject(stickerOrName)) {
+            stickerOrName = stickerOrName.name;
+          }
 
-      model.hasSticker = function(stickerOrName) {
-        if (!stickersMap) {
-          stickersMap = _.transform(this.getStickers(), function(result, sticker) {
-            result[sticker.name] = sticker;
-          }, {});
-        }
+          return _.has(stickersMap, stickerOrName);
+        };
 
-        if (_.isObject(stickerOrName)) {
-          stickerOrName = stickerOrName.name;
-        }
+        model.loadSvg = function (node, tree) {
+          var deferred = $q.defer();
+          var key = [this.id, node, tree].join(':');
+          var cachedSvg = svgCache.get(key);
+          if (cachedSvg) {
+            deferred.resolve(cachedSvg);
+          } else {
+            this.post('svg', {
+              nodes: [node],
+              tree: tree
+            }).then(function(svg) {
+              svg = svgResult(svg);
+              svgCache.put(key, svg);
+              deferred.resolve(svg);
+            }, deferred.reject);
+          }
 
-        return _.has(stickersMap, stickerOrName);
-      };
-
-      model.loadSvg = function (node, tree) {
-        var deferred = $q.defer();
-        var key = [this.id, node, tree].join(':');
-        var cachedSvg = svgCache.get(key);
-        if (cachedSvg) {
-          deferred.resolve(cachedSvg);
-        } else {
-          this.post('svg', {
-            nodes: [node],
-            tree: tree
-          }).then(function(svg) {
-            svg = svgResult(svg);
-            svgCache.put(key, svg);
-            deferred.resolve(svg);
-          }, deferred.reject);
-        }
-
-        return deferred.promise;
-      };
-      return model;
+          return deferred.promise;
+        };
+        return model;
+      });
     });
+
+    var service = restangular.service('treebanks');
+
+    service.recentlyUsed = function () {
+      var recent = localStorageService.get(recentStorageKey) || [];
+      return service.getList().then(function(list) {
+        var tbIndex = _.indexBy(list, 'id'), result = [];
+
+        for (var i = 0; i < recent.length; i++) {
+          var tbId = recent[i];
+          if (tbIndex[tbId]) {
+            result.push(tbIndex[tbId]);
+          }
+        }
+
+        return result;
+      });
+    };
+
+    service.addRecentlyUsed = function (tbId) {
+      var recent = localStorageService.get(recentStorageKey) || [];
+      recent.unshift(tbId);
+      localStorageService.set(recentStorageKey, _.uniq(recent));
+    };
+
+    return service;
   });
-  return restangular.service('treebanks');
-});


### PR DESCRIPTION
One of the possible solutions to how to navigate in the ever growing list of treebanks:
Store somewhere the list of N (5?) most recently used treebanks and show them on top of the list of treebanks to select.
If the user has signed in, the server could remember their recent treebanks for them.
Or there might be a section in the user's profile where they could mark their favorite treebanks manually.
If the user works anonymously, a cookie in their client software could store the information about the most recently used corpora.
