### PR TITLE
Use treebank name in URL

### DIFF
--- a/app/home/home.jade
+++ b/app/home/home.jade
@@ -18,11 +18,11 @@ main.ui.page.grid
     .column
       h2.header Recently Used
       .ui.divided.items(ng-if="recentlyUsed.length > 0")
-        div(treebank-list-item="tb" ui-sref="treebank.index({treebankId: tb.id})" ng-repeat="tb in recentlyUsed track by tb.id")
+        div(treebank-list-item="tb" ng-repeat="tb in recentlyUsed track by tb.id")
       .ui.info.message(ng-if="recentlyUsed.length == 0")
         .header No recent treebanks
         | You will find recently used treebanks here.
     .column
       h2 Featured Treebanks
       .ui.divided.items
-        div(treebank-list-item="tb" ui-sref="treebank.index({treebankId: tb.id})" ng-repeat="tb in featured track by tb.id")
+        div(treebank-list-item="tb" ng-repeat="tb in featured track by tb.id")

--- a/app/treebank/browse.jade
+++ b/app/treebank/browse.jade
@@ -50,6 +50,6 @@ main.ui.page.one.column.grid
         .header These aren't the treebanks you're looking for...
         | Sorry, no treebanks match the current filter. Try deselect the labels or reset the filter entirely.
       .ui.divided.items(ng-hide="vm.filter.isEmpty")
-        div(treebank-list-item="tb" ui-sref="treebank.index({treebankId: tb.id})" ng-repeat="tb in vm.filter.treebanksList() track by tb.id")
+        div(treebank-list-item="tb" ng-repeat="tb in vm.filter.treebanksList() track by tb.id")
       //- .treebank-box(ng-repeat="tb in treebanks | treebankFilter : filter track by tb.id")
       //-   treebank-box/(treebank="tb")

--- a/app/treebank/treebank-list-item.directive.js
+++ b/app/treebank/treebank-list-item.directive.js
@@ -1,4 +1,4 @@
-angular.module('pmltq.treebank').directive('treebankListItem', function() {
+angular.module('pmltq.treebank').directive('treebankListItem', function($state) {
   return {
     restrict: 'A',
     replace: true,
@@ -6,9 +6,14 @@ angular.module('pmltq.treebank').directive('treebankListItem', function() {
       treebank: '=treebankListItem'
     },
     templateUrl: 'treebank/treebank-list-item.directive.html',
-    link: function($scope, $element, $attr) {
-      $attr.$observe('href', function(url) {
-        $scope.url = url;
+    link: function($scope) {
+
+      $scope.$watch('treebank', function(treebank) {
+        if (treebank) {
+          $scope.url = $state.href('treebank.index', {treebankId: treebank.name});
+        } else {
+          $scope.url = '';
+        }
       });
     }
   };

--- a/app/treebank/treebank.routes.js
+++ b/app/treebank/treebank.routes.js
@@ -17,11 +17,7 @@ angular.module('pmltq.treebank').config(function($stateProvider) {
         return historyApi.getList();
       },
       queryParams: function (QueryParams) {
-        return new QueryParams(
-          "t-node [ gram/deontmod ~ '(deb|hrt|vol|perm|poss|fac)', a/lex.rf a-node [] ];",
-          100,
-          30
-        );
+        return new QueryParams('', 100, 30);
       }
     }
   });


### PR DESCRIPTION
Now we started using id just because it's simple for communication with api.

Don't forget to change it back