### PR TITLE
Cache query params when submited

### DIFF
--- a/app/result/result-holder.factory.js
+++ b/app/result/result-holder.factory.js
@@ -29,6 +29,7 @@ angular.module('pmltq.result').factory('resultHolder', function(constants, _) {
     resultHolder.submit = function(treebank, queryParams) {
       resultHolder.submited = true;
       resultHolder.queryParams = queryParams;
+      queryParams.cache(); // save to cache
       treebank.post('query', queryParams.params())
               .then(resultHolder.set, resultHolder.setErr);
     };


### PR DESCRIPTION
It can happen that params are not saved when query is inserted by other means e.g. from Help